### PR TITLE
Server settings

### DIFF
--- a/src/DropdownMenu.svelte
+++ b/src/DropdownMenu.svelte
@@ -1,0 +1,79 @@
+<script>
+    import { current_page } from './stores.js';
+    import { hover_color, text_on_color, highlight } from './theme.js';
+
+    let menu_open = false;
+    let main_page = true;
+
+    function openMenu() {
+        menu_open = !menu_open;
+    }
+
+    function serverSettings() {
+
+    }
+
+    function pastRecordings() {
+        current_page.set("recordings");
+    }
+
+    function mainPage() {
+        current_page.set("main");
+    }
+</script>
+
+<style>
+    .material-icons {
+        color: var(--primary-color);
+        margin-top: 5px;
+        margin-right: 15px;
+        cursor: pointer;
+        transition: 0.3s;
+        border: none;
+        background-color: rgba(0,0,0,0);
+        padding: 0;
+    }
+
+    .material-icons:hover {
+        box-shadow: 8px 8px  var(--shadow-color);
+    }
+
+    .dropdown-content {
+        display: flex;
+        flex-direction: column;
+        position: absolute;
+        background-color: #f9f9f9;
+        min-width: 160px;
+        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+        
+        z-index: 1;
+        right: 30px;
+        top: 30px;
+    }
+
+    span {
+        padding: 10px;
+        text-align: center;
+    }
+
+    span:hover {
+        background-color: lightgray;
+        transition-duration: 400ms;
+        
+    }
+</style>
+
+<button on:click={openMenu} class="material-icons" style="--primary-color:{$text_on_color}; --shadow-color:{$highlight}">
+    { menu_open ? 'menu_open' : 'menu' }
+</button>
+
+{#if menu_open}
+    <div class="dropdown-content">
+        <span on:click={serverSettings} style="--hover-color:{$hover_color}">Change Server Settings</span>
+        {#if $current_page == "main"}
+            <span on:click={pastRecordings} style="--hover-color:{$hover_color}">Show Past Recordings</span>
+        {:else}
+            <span on:click={mainPage} style="--hover-color:{$hover_color}">Show Controls</span>
+        {/if}
+    </div>
+{/if}

--- a/src/DropdownMenu.svelte
+++ b/src/DropdownMenu.svelte
@@ -1,20 +1,25 @@
 <script>
     import ServerSettingsModal from './ServerSettingsModal.svelte';
-    import { current_page, update_config, config_object } from './stores.js';
+    import { current_page, query_config, change_config } from './stores.js';
     import { hover_color, text_on_color, highlight } from './theme.js';
     import FancyInput from './FancyInput.svelte';
 
     let menu_open = false;
     let main_page = true;
     let open_modal = false;
+    let config_data = {};
     let config_promise;
+    
 
     function openMenu() {
         menu_open = !menu_open;
     }
 
     function serverSettings() {
-        config_promise = update_config();
+        config_promise = query_config().then((value) => {
+            config_data = value.data.config;
+            config_data.excluded_djs = JSON.stringify(config_data.excluded_djs);
+        });
         menu_open = false;
         open_modal = true;
     }
@@ -35,6 +40,12 @@
                 menu_open = false;
             }
         }
+    }
+
+    function submit() {
+        config_data.excluded_djs = JSON.parse(config_data.excluded_djs);
+        console.log(config_data);
+        change_config(config_data).then(result => console.log(result));
     }
 </script>
 
@@ -75,7 +86,7 @@
     }
 
     span:hover {
-        background-color: lightgray;
+        background-color: var(--hover-color);
         transition-duration: 400ms;
         
     }
@@ -98,10 +109,6 @@
     .modal-title {
         font-size: 20px;
     }
-
-    input {
-        width: 250px;
-    }
 </style>
 
 <button on:click={openMenu} class="material-icons" style="--primary-color:{$text_on_color}; --shadow-color:{$highlight}">
@@ -111,28 +118,28 @@
 {#if menu_open}
     <div class="dropdown-content">
         <span on:click={serverSettings} style="--hover-color:{$hover_color}">Change Server Settings</span>
-        {#if $current_page == "main"}
+        <!-- {#if $current_page == "main"}
             <span on:click={pastRecordings} style="--hover-color:{$hover_color}">Show Past Recordings</span>
         {:else}
             <span on:click={mainPage} style="--hover-color:{$hover_color}">Show Controls</span>
-        {/if}
+        {/if} -->
     </div>
     <div class="menu-background" on:click="{() => menu_open = false}"></div>
 {/if}
 
 {#if open_modal}
-    <ServerSettingsModal on:close="{() => open_modal = false}">
+    <ServerSettingsModal on:close="{() => open_modal = false}" on:submission={submit}>
         <div class="modal-title" slot="header">Change your server settings</div>
         {#await config_promise}
             loading
         {:then value}
             <div class="form-input">
-                <FancyInput id="api_uri" label="API URI" value={value.data.config.api_uri}></FancyInput>
-                <FancyInput id="server_uri" label="Server URI" value={value.data.config.server_uri}></FancyInput>
-                <FancyInput id="stream_uri" label="Stream URI" value={value.data.config.stream_uri}></FancyInput>
-                <FancyInput id="poll_interval" label="Poll Interval" value={value.data.config.poll_interval}></FancyInput>
-                <FancyInput id="excluded_djs" label="Excluded DJs" value={value.data.config.excluded_djs}></FancyInput>
-                <FancyInput id="export_folder" label="Export Folder" value={value.data.config.export_folder}></FancyInput>
+                <FancyInput id="api_uri" label="API URI" bind:value={config_data.api_uri}></FancyInput>
+                <FancyInput id="server_uri" label="Server URI" bind:value={config_data.server_uri}></FancyInput>
+                <FancyInput id="stream_uri" label="Stream URI" bind:value={config_data.stream_uri}></FancyInput>
+                <FancyInput id="poll_interval" label="Poll Interval" bind:value={config_data.poll_interval}></FancyInput>
+                <FancyInput id="excluded_djs" label="Excluded DJs" hint_text="JSON array of strings" bind:value={config_data.excluded_djs}></FancyInput>
+                <FancyInput id="export_folder" label="Export Folder" hint_text="Leave empty for same directory as file" bind:value={config_data.export_folder}></FancyInput>
             </div>
         {:catch error}
             {error.message}

--- a/src/FancyInput.svelte
+++ b/src/FancyInput.svelte
@@ -1,0 +1,84 @@
+<script>
+    import { primary, highlight, input_hover_color } from './theme.js';
+    export let value = "";
+    export let label = "";
+    export let border_color = $highlight;
+    export let hover_color = $input_hover_color;
+</script>
+
+<style>
+    input:hover {
+        border-color: var(--hover-color);
+    }
+
+    input:focus {
+        border-color: var(--border-color);
+        transition-duration: 400ms;
+        border-radius: 5px;
+    }
+
+    input {
+        margin: 8px;
+        border-width: 2px;
+        height: 40px;
+        border-radius: 5px;
+        width: 250px;
+    }
+
+    .form-field {
+        display: flex;
+        margin-bottom: 16px;
+    }
+
+    .form-field-control {
+        display: flex;
+        flex-shrink: 1;
+        border-radius: 8px 8px 0 0;
+        overflow: hidden;
+        position: relative;
+        width: 100%;
+    }
+
+    label {
+        font-weight: normal;
+        left: 0;
+        margin: 0;
+        padding-left: 15px;
+        padding-top: 7px;
+        position: absolute;
+        top: 0;
+        pointer-events: none;
+        background: none;
+        
+    }
+
+    input:focus + label {
+        color: var(--active-color);
+        transform: scale(.75, .75) translate(-10px, -20px);
+        transition-duration: 400ms;
+        padding: 0% 5% 0%;
+        margin-left: 5%;
+        background: white;
+        background-clip: padding-box;
+    }
+
+    input:not(:placeholder-shown) + label {
+        transform: scale(.75, .75) translate(-10px, -20px);
+        transition-duration: 400ms;
+        padding: 0% 5% 0%;
+        margin-left: 5%;
+        background: white;
+        background-clip: padding-box;
+    }
+
+    input:placeholder-shown + label {
+        transition-duration: 400ms;
+    }
+</style>
+
+<div class="form-field">
+    <div class="form-field-control">
+        <input {value} style="--border-color:{border_color}; --hover-color:{hover_color}" placeholder=" ">
+        <label style="--active-color:{border_color}">{label}</label>
+    </div>
+</div>

--- a/src/FancyInput.svelte
+++ b/src/FancyInput.svelte
@@ -1,9 +1,13 @@
 <script>
-    import { primary, highlight, input_hover_color } from './theme.js';
+    import { primary, highlight, input_hover_color, sub_text_color, hover_color } from './theme.js';
     export let value = "";
     export let label = "";
     export let border_color = $highlight;
-    export let hover_color = $input_hover_color;
+    export let active_color = $input_hover_color;
+    export let label_color = $sub_text_color;
+    export let id;
+    export let hint_text = "";
+    export let hint_text_color = $hover_color;
 </script>
 
 <style>
@@ -27,6 +31,7 @@
 
     .form-field {
         display: flex;
+        flex-direction: column;
         margin-bottom: 16px;
     }
 
@@ -39,7 +44,7 @@
         width: 100%;
     }
 
-    label {
+    .float-text {
         font-weight: normal;
         left: 0;
         margin: 0;
@@ -49,10 +54,11 @@
         top: 0;
         pointer-events: none;
         background: none;
+        color: var(--text-color);
         
     }
 
-    input:focus + label {
+    input:focus + .float-text {
         color: var(--active-color);
         transform: scale(.75, .75) translate(-10px, -20px);
         transition-duration: 400ms;
@@ -62,7 +68,7 @@
         background-clip: padding-box;
     }
 
-    input:not(:placeholder-shown) + label {
+    input:not(:placeholder-shown) + .float-text {
         transform: scale(.75, .75) translate(-10px, -20px);
         transition-duration: 400ms;
         padding: 0% 5% 0%;
@@ -71,14 +77,22 @@
         background-clip: padding-box;
     }
 
-    input:placeholder-shown + label {
+    input:placeholder-shown + .float-text {
         transition-duration: 400ms;
+    }
+
+    .hint-text {
+        color: var(--text-color);
+        font-size: 14px;
+        text-align: center;
+        line-height: 0;
     }
 </style>
 
 <div class="form-field">
     <div class="form-field-control">
-        <input {value} style="--border-color:{border_color}; --hover-color:{hover_color}" placeholder=" ">
-        <label style="--active-color:{border_color}">{label}</label>
+        <input {id} bind:value={value} style="--border-color:{border_color}; --hover-color:{active_color}" placeholder=" ">
+        <label class="float-text" style="--active-color:{border_color}; --text-color:{label_color}">{label}</label>
     </div>
+    <label class="hint-text" style="--text-color:{hint_text_color}">{hint_text}</label>
 </div>

--- a/src/Footer.svelte
+++ b/src/Footer.svelte
@@ -1,24 +1,14 @@
 <script>
-	import ProgressBar from './progress_bar.svelte';
+    import ProgressBar from './progress_bar.svelte';
+    import StreamStatus from './StreamStatus.svelte';
     import { primary, text_on_color } from './theme.js';
-    import { valid_object, api_object, misc_object } from './stores';
+    import { api_object, misc_object } from './stores';
 
     function format_seconds(seconds) {
         var measuredTime = new Date(null);
         measuredTime.setSeconds(seconds);
         return measuredTime.toISOString().substr(11, 8);
     }
-
-    let state_icon = "pause";
-
-    const unsub_valid = valid_object.subscribe((value) => {
-        state_icon = "pause";
-        if (value.force_stop) {
-            state_icon = "not_interested";
-        } else if (value.valid_dj) {
-            state_icon = "play_arrow";
-        }
-    });
 
     let current_time = format_seconds(0);
     let current_stamp = 0;
@@ -78,14 +68,6 @@
         width: 70%;
         margin: auto;
     }
-
-    .material-icons {
-        color: var(--primary-color);
-        margin-top: auto;
-        margin-bottom: auto;
-        margin-left: 15px;
-        margin-right: 15px;
-    }
 </style>
 
 <footer style="--primary-color:{$primary}">
@@ -104,6 +86,6 @@
             <p style="--primary-color:{$text_on_color}">Not Recording</p>
             {/if}
         </div>
-        <i class="material-icons" style="--primary-color:{$text_on_color}">{state_icon}</i>
+        <StreamStatus></StreamStatus>
     </div>
 </footer>

--- a/src/Header.svelte
+++ b/src/Header.svelte
@@ -1,4 +1,5 @@
 <script>
+    import DropdownMenu from './DropdownMenu.svelte';
     import { primary, background, base_text_color, text_on_color } from './theme.js';
     import { server_object, api_object } from './stores';
 </script>
@@ -9,7 +10,7 @@
         background: var(--primary-color);
         display: inline-flex;
         flex-direction: row;
-        justify-content: space-around;
+        justify-content: flex-end;
         line-height: 40px;
     }
     
@@ -19,27 +20,34 @@
         text-align: center;
         font-size: 20px;
     }
+
+    .text-alignment {
+        display: inline-flex;
+        flex-direction: row;
+        justify-content: space-around;
+        width: 100%;
+    }
 </style>
 
 <header style="--primary-color:{$primary}">
-    <div>
-        <p style="--primary-color:{$text_on_color}">
-            {$server_object.server_name} - {$server_object.server_description}
-        </p>
+    <div class="text-alignment">
+        <div>
+            <p style="--primary-color:{$text_on_color}">
+                {$server_object.server_name} - {$server_object.server_description}
+            </p>
+        </div>
+        <div>
+            <p style="--primary-color:{$text_on_color}">
+                {$server_object.audio_format} | {$server_object.bitrate}kb/s | {$server_object.sample_rate}Hz
+            </p>
+        </div>
+        <div>
+            <p style="--primary-color:{$text_on_color}">
+                Listeners: {$api_object.listeners}
+            </p>
+        </div>
     </div>
     <div>
-        <p style="--primary-color:{$text_on_color}">
-            {$server_object.audio_format} | {$server_object.bitrate}kb/s | {$server_object.sample_rate}Hz
-        </p>
-    </div>
-    <div>
-        <p style="--primary-color:{$text_on_color}">
-            Listeners: {$api_object.listeners}
-        </p>
-    </div>
-    <div>
-        <p style="--primary-color:{$text_on_color}">
-            Server Settings
-        </p>
+        <DropdownMenu></DropdownMenu>
     </div>
 </header>

--- a/src/Main.svelte
+++ b/src/Main.svelte
@@ -41,7 +41,6 @@
 
 <main style="--primary-color:{$background}">
     <div class="top">
-        <!-- <img src={$misc_object.dj_image_link} alt="dj_pic" class="dj-pic" /> -->
         <div class="dj-pic">
             <img src={$misc_object.dj_image_link} alt="dj_pic" class="dj-pic" />
         </div>

--- a/src/Main.svelte
+++ b/src/Main.svelte
@@ -34,7 +34,8 @@
     }
 
     img {
-        max-width: 100%;
+        max-width: 90%;
+        margin-top: 5%;
     }
 </style>
 

--- a/src/ServerSettingsModal.svelte
+++ b/src/ServerSettingsModal.svelte
@@ -1,0 +1,81 @@
+<script>
+	import { createEventDispatcher, onDestroy } from 'svelte';
+
+	const dispatch = createEventDispatcher();
+	const close = () => dispatch('close');
+
+	let modal;
+
+	const handle_keydown = e => {
+		if (e.key === 'Escape') {
+			close();
+			return;
+		}
+
+		if (e.key === 'Tab') {
+			// trap focus
+			const nodes = modal.querySelectorAll('*');
+			const tabbable = Array.from(nodes).filter(n => n.tabIndex >= 0);
+
+			let index = tabbable.indexOf(document.activeElement);
+			if (index === -1 && e.shiftKey) index = 0;
+
+			index += tabbable.length + (e.shiftKey ? -1 : 1);
+			index %= tabbable.length;
+
+			tabbable[index].focus();
+			e.preventDefault();
+		}
+	};
+
+	const previously_focused = typeof document !== 'undefined' && document.activeElement;
+
+	if (previously_focused) {
+		onDestroy(() => {
+			previously_focused.focus();
+		});
+	}
+</script>
+
+<svelte:window on:keydown={handle_keydown}/>
+
+<div class="modal-background" on:click={close}></div>
+
+<div class="modal" role="dialog" aria-modal="true" bind:this={modal}>
+	<slot name="header"></slot>
+	<hr>
+	<slot></slot>
+	<hr>
+
+	<!-- svelte-ignore a11y-autofocus -->
+	<button autofocus on:click={close}>close modal</button>
+</div>
+
+<style>
+	.modal-background {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background: rgba(0,0,0,0.3);
+	}
+
+	.modal {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		width: calc(100vw - 4em);
+		max-width: 40em;
+		max-height: calc(100vh - 4em);
+		overflow: auto;
+		transform: translate(-50%,-50%);
+		padding: 1em;
+		border-radius: 0.2em;
+		background: white;
+	}
+
+	button {
+		display: block;
+	}
+</style>

--- a/src/ServerSettingsModal.svelte
+++ b/src/ServerSettingsModal.svelte
@@ -1,8 +1,12 @@
 <script>
-	import { createEventDispatcher, onDestroy } from 'svelte';
+    import { createEventDispatcher, onDestroy } from 'svelte';
 
 	const dispatch = createEventDispatcher();
-	const close = () => dispatch('close');
+    const close = () => dispatch('close');
+    const submission = () => {
+        dispatch('submission');
+        dispatch('close');
+    }
 
 	let modal;
 
@@ -43,12 +47,18 @@
 
 <div class="modal" role="dialog" aria-modal="true" bind:this={modal}>
 	<slot name="header"></slot>
-	<hr>
+    <br>
+	<!-- <hr> -->
 	<slot></slot>
-	<hr>
+    <br>
+	<!-- <hr> -->
 
 	<!-- svelte-ignore a11y-autofocus -->
-	<button autofocus on:click={close}>close modal</button>
+	<!-- <button autofocus on:click={close}>close modal</button> -->
+    <div class="user-actions">
+        <span class="cancel" on:click={close}>Cancel</span>
+        <span class="accept" on:click={submission}>Accept</span>
+    </div>
 </div>
 
 <style>
@@ -66,16 +76,48 @@
 		left: 50%;
 		top: 50%;
 		width: calc(100vw - 4em);
-		max-width: 40em;
+		max-width: 38em;
 		max-height: calc(100vh - 4em);
 		overflow: auto;
 		transform: translate(-50%,-50%);
 		padding: 1em;
 		border-radius: 0.2em;
 		background: white;
+        box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.3), 0 6px 20px 0 rgba(0, 0, 0, 0.29);
 	}
 
 	button {
 		display: block;
 	}
+
+    .user-actions {
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    .cancel {
+        color: red;
+        padding-left: 10px;
+        padding-right: 10px;
+        border-radius: 5px;
+        cursor: pointer;
+    }
+
+    .cancel:hover {
+        background: rgb(253, 229, 232);
+        transition-duration: 400ms;
+    }
+
+    .accept {
+        color: blue;
+        padding-left: 10px;
+        padding-right: 10px;
+        border-radius: 5px;
+        cursor: pointer;
+    }
+
+    .accept:hover {
+        background: rgb(235, 246, 250);
+        transition-duration: 400ms;
+    }
 </style>

--- a/src/StreamStatus.svelte
+++ b/src/StreamStatus.svelte
@@ -1,0 +1,27 @@
+<script>
+    import { primary, text_on_color } from './theme.js';
+    import { valid_object } from './stores';
+
+    let state_icon = "pause";
+
+    const unsub_valid = valid_object.subscribe((value) => {
+        state_icon = "pause";
+        if (value.force_stop) {
+            state_icon = "not_interested";
+        } else if (value.valid_dj) {
+            state_icon = "play_arrow";
+        }
+    });
+</script>
+
+<style>
+    .material-icons {
+        color: var(--primary-color);
+        margin-top: auto;
+        margin-bottom: auto;
+        margin-left: 15px;
+        margin-right: 15px;
+    }
+</style>
+
+<i class="material-icons" style="--primary-color:{$text_on_color}">{state_icon}</i>

--- a/src/progress_bar.svelte
+++ b/src/progress_bar.svelte
@@ -28,7 +28,7 @@
         color: var(--primary-color);
         background: var(--background-color);
         border: none;
-        height: 15px;
+        height: 10px;
     }
     
     progress::-webkit-progress-bar {background-color: var(--background-color); width: 100%}
@@ -38,4 +38,4 @@
     progress::-webkit-progress-value { background: var(--primary-color); }
 </style>
 
-<progress value={$progress} style="--primary-color:{$highlight}; --background-color:{$background}"></progress>
+<progress value={$progress} style="--primary-color:{$highlight}; --background-color:{$primary}"></progress>

--- a/src/progress_bar.svelte
+++ b/src/progress_bar.svelte
@@ -15,7 +15,8 @@
             const current = value.current_time - value.start_time;
             const end = value.end_time - value.start_time;
             const prog = current / end;
-            if (prog) progress.set(prog);
+            if (end === 0) progress.set(1);
+            else if (prog) progress.set(prog);
         }
     });
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -3,9 +3,7 @@ import fetchGraphQL from 'fetch-graphql';
 
 export const poll_interval = writable(5000);
 
-export const start_time = writable(0);
-
-export const current_time = writable(5);
+export const current_page = writable("main");
 
 export const end_time = writable(10);
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -36,15 +36,14 @@ export const valid_object = writable({
     force_stop: false
 });
 
-// setInterval(() => {
-//     current_time.update(1);
-//     // if (curr_t > $end_time) {
-//     //     current_time.set($start_time);
-//     // }
-// }, 5000)
-
-// api_object.subscribe(value => console.log(value));
-// server_object.subscribe(value => console.log(`server: ${value}`));
+export const config_object = writable({
+    api_uri: "",
+    server_uri: "",
+    stream_uri: "",
+    poll_interval: 0,
+    excluded_djs: [],
+    export_folder: ""
+})
 
 const api_query = `
 query {
@@ -92,6 +91,18 @@ query {
     }
 }`;
 
+const config_query = `
+query {
+    config {
+        api_uri,
+        server_uri,
+        stream_uri,
+        poll_interval,
+        excluded_djs,
+        export_folder
+    }
+}`;
+
 const graphql_url = 'http://localhost:4000/graphql';
 
 function update_objects() {
@@ -115,6 +126,15 @@ function update_objects() {
         {},
         valid_query,
     ).then(result => valid_object.set(result.data.valid));
+}
+
+export function update_config() {
+    return fetchGraphQL(
+        graphql_url,
+        {},
+        config_query,
+    );
+    // ).then(result => config_object.set(result.data.config_data));
 }
 
 update_objects();

--- a/src/stores.js
+++ b/src/stores.js
@@ -103,6 +103,19 @@ query {
     }
 }`;
 
+const mutate_config_query = (config_data) => `
+    mutation {
+        updateConfig(config: {
+            api_uri: ${JSON.stringify(config_data.api_uri)},
+            excluded_djs: ${JSON.stringify(config_data.excluded_djs)},
+            export_folder: ${JSON.stringify(config_data.export_folder)},
+            poll_interval: ${JSON.stringify(config_data.poll_interval)},
+            server_uri: ${JSON.stringify(config_data.server_uri)},
+            stream_uri: ${JSON.stringify(config_data.stream_uri)}
+        })
+    }
+`;
+
 const graphql_url = 'http://localhost:4000/graphql';
 
 function update_objects() {
@@ -128,13 +141,22 @@ function update_objects() {
     ).then(result => valid_object.set(result.data.valid));
 }
 
-export function update_config() {
+export function query_config() {
     return fetchGraphQL(
         graphql_url,
         {},
         config_query,
     );
     // ).then(result => config_object.set(result.data.config_data));
+}
+
+export function change_config(new_config) {
+    console.log(mutate_config_query(new_config));
+    return fetchGraphQL(
+        graphql_url,
+        {},
+        mutate_config_query(new_config),
+    );
 }
 
 update_objects();

--- a/src/theme.js
+++ b/src/theme.js
@@ -12,4 +12,6 @@ export const base_text_color = writable("black");
 
 export const sub_text_color = writable("gray");
 
-export const hover_color = writable("lightgray")
+export const hover_color = writable("lightgray");
+
+export const input_hover_color = writable("yellow");

--- a/src/theme.js
+++ b/src/theme.js
@@ -11,3 +11,5 @@ export const text_on_color = writable("white");
 export const base_text_color = writable("black");
 
 export const sub_text_color = writable("gray");
+
+export const hover_color = writable("lightgray")


### PR DESCRIPTION
Adds server settings functionality, as well as a few other things:

- Introduces some minor css changes to existing components
-- Progress bar background is now $primary
-- DJ image now has some padding so it doesn't take up all of its space
- Added a dropdown menu for the server settings (and past recordings page later on)
- Added material-ui-like input component
- Server settings modal with mutation call to change the server settings
- Still no snackbar replacement, so no feedback from any of these actions