### PR TITLE
Improve past recs

### DIFF
--- a/src/PastRecordings.svelte
+++ b/src/PastRecordings.svelte
@@ -98,8 +98,8 @@
                 </div>
             </div>
             <div class="song-list">
-                {#each value.data.full_recording.songs as song}
-                    <RecordedSong src={`http://localhost:4000/${modal_folder}/${song}`} {song}></RecordedSong>
+                {#each value.data.full_recording.songs as song, index}
+                    <RecordedSong src={`http://localhost:4000/${modal_folder}/${song.file}`} {song} {index}></RecordedSong>
                 {:else}
                     <p>No songs found.</p>
                 {/each}

--- a/src/PastRecordings.svelte
+++ b/src/PastRecordings.svelte
@@ -1,63 +1,111 @@
 <script>
-    import { update_past_recordings, past_recordings_object } from './stores.js';
+    import { update_past_recordings, past_recordings_object, query_full_recordings } from './stores.js';
+    import { sub_text_color } from './theme.js';
+    import RecordingCard from './RecordingCard.svelte';
+    import ServerSettingsModal from './ServerSettingsModal.svelte';
+    import RecordedSong from './RecordedSong.svelte';
+
+    function open_recording(folder) {
+        songs_promise = query_full_recordings(folder);
+        show_recording_modal = true;
+        modal_title = folder.split(' ')[1];
+        modal_date = get_date(folder.split(' ')[0]);
+        modal_folder = folder;
+    }
 
     function get_date(seconds) {
-    var measuredTime = new Date(null);
-    measuredTime.setSeconds(seconds);
-    return measuredTime.toString();
-}
+        var date = new Date(null);
+        date.setSeconds(seconds);
+        return date.toString();
+    }
+
+    let show_recording_modal = false;
+    let modal_title = "";
+    let modal_date = "";
+    let modal_folder = "";
+    let songs_promise;
 </script>
 
 <style>
-    .sub-text {
-        color: gray;
-        max-width: 75%
-    }
-    .column-display {
-        display: flex;
-        flex-direction: column;
-        margin: auto;
-    }
-    .recording-group {
+    .card-display {
         display: flex;
         flex-direction: row;
+        flex-wrap: wrap;
+        margin: auto;
         justify-content: center;
     }
-    .folder-title {
-        min-width: 200px;
-        width: 30%;
-    }
+
     .song-list {
-        max-height: 400px;
-        overflow-y: scroll;
-        min-width: 400px;
-        width: 60%;
+        display: flex;
+        flex-direction: column;
+        max-height: 600px;
+        overflow-y: auto;
+    }
+
+    .modal-title {
+        font-size: 20px;
+    }
+
+    .full-date {
+        color: var(--primary-color);
+    }
+
+    .columns {
+        display: flex;
+        flex-direction: column;
+    }
+
+    h1 {
+        text-align: center;
     }
 </style>
 
-<div class="column-display">
+<div class="columns">
     <h1>Past Recordings</h1>
-    {#await $past_recordings_object}
-        <p>Fetching recordings</p>
-    {:then value}
-        {#each value.data.past_recordings.recordings as {folder, songs}}
-            <div class="recording-group">
-                <div class="folder-title">
-                    <p>{folder}</p>
-                    <p class="sub-text">{get_date(folder.split(' ')[0])}</p>
+
+    <div class="card-display">
+        {#await $past_recordings_object}
+            <p>Fetching recordings</p>
+        {:then value}
+            {#each value.data.past_recordings.recordings as {folder, songs, cover}}
+                <RecordingCard 
+                    background_source={`http://localhost:4000/${cover}`}
+                    folder={folder}
+                    songs={songs}
+                    on:open="{() => open_recording(folder)}"
+                >
+                </RecordingCard>
+            {:else}
+                <p>No recordings yet.</p>
+            {/each}
+        {:catch error}
+        <p>Caught error: {error}</p>
+        {/await}
+    </div>
+</div>
+
+{#if show_recording_modal}
+    <ServerSettingsModal on:close="{() => show_recording_modal = false}" use_submission={false}>
+        {#await songs_promise}
+            loading
+        {:then value}
+            <div slot="header">
+                <div class="modal-title">
+                    {modal_title}
                 </div>
-                <div class="song-list">
-                    {#each songs as title}
-                        <p>{title}</p>
-                    {:else}
-                        <p>Empty recording.</p>
-                    {/each}
+                <div class="full-date" style="--primary-color:{$sub_text_color}">
+                    {modal_date}
                 </div>
             </div>
-        {:else}
-            <p>No recordings yet.</p>
-        {/each}
-    {:catch error}
-    <p>Caught error: {error}</p>
-    {/await}
-</div>
+            <div class="song-list">
+                {#each value.data.full_recording.songs as song}
+                    <RecordedSong src={`http://localhost:4000/${modal_folder}/${song}`} {song}></RecordedSong>
+                {:else}
+                    <p>No songs found.</p>
+                {/each}
+            </div>
+        {:catch error}
+            {error.message}
+        {/await}
+    </ServerSettingsModal>
+{/if}

--- a/src/RecordedSong.svelte
+++ b/src/RecordedSong.svelte
@@ -1,0 +1,92 @@
+<script context="module">
+	const elements = new Set();
+
+	export function stopAll() {
+		elements.forEach(element => {
+			element.pause();
+		});
+	}
+</script>
+
+<script>
+	import { onMount } from 'svelte';
+	 import { hover_color, primary_light, sub_text_color } from './theme.js';
+
+	export let src;
+	export let song;
+	export let index;
+
+	let audio;
+	let paused = true;
+	let duration;
+
+	onMount(() => {
+		elements.add(audio);
+		return () => elements.delete(audio);
+	});
+
+	function stopOthers() {
+		elements.forEach(element => {
+			if (element !== audio) element.pause();
+		});
+	}
+
+	function formatSeconds(seconds) {
+		if (isNaN(seconds)) return "No Data";
+		var sec_num = parseInt(seconds, 10)
+		var hours   = Math.floor(sec_num / 3600)
+		var minutes = Math.floor(sec_num / 60) % 60
+		var seconds = sec_num % 60
+
+		return [hours,minutes,seconds]
+			.map(v => v < 10 ? "0" + v : v)
+			.filter((v,i) => v !== "00" || i > 0)
+			.join(":")
+		}
+</script>
+
+<style>
+	span {
+		cursor: pointer;
+		word-wrap: break-word;
+	}
+
+    span:hover {
+        background-color: var(--hover-color);
+        transition-duration: 400ms;
+        
+    }
+
+	.playing {
+		background-color: var(--playing-color);
+	}
+
+	.sub-text {
+		color: var(--primary-color);
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+</style>
+
+
+<span 
+	on:click={paused ? audio.play() : audio.pause()}
+	class:playing={!paused}
+	style="--hover-color:{$hover_color}; --playing-color:{$primary_light}"
+>
+	<p>{index + 1}. {song.title}</p>
+	<div class="sub-text" style="--primary-color:{$sub_text_color}">
+		<div>{song.artist}</div>
+		<div>{formatSeconds(duration)}</div>
+	</div>
+</span>
+
+<audio
+	bind:this={audio}
+	bind:paused
+	bind:duration
+	on:play={stopOthers}
+	{src}
+	preload="metadata"
+></audio>

--- a/src/RecordingCard.svelte
+++ b/src/RecordingCard.svelte
@@ -1,0 +1,82 @@
+<script>
+    import { primary, background, base_text_color, sub_text_color } from './theme.js';
+    import { createEventDispatcher } from 'svelte';
+    export let background_source;
+    export let folder;
+    export let songs;
+
+    
+    let dj_name = folder.split(' ')[1];
+    let date = folder.split(' ')[0]
+
+    function get_date(seconds) {
+        var date = new Date(null);
+        date.setSeconds(seconds);
+        return date.toString().split(' ').splice(0, 4).join(' ');
+    }
+
+    const dispatch = createEventDispatcher();
+    const open_recording = () => dispatch('open');
+</script>
+
+<style>
+    .card {
+        height: 250px;
+        width: 200px;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        margin: 10px;
+        transition-duration: 500ms;
+        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.1);
+        cursor: pointer;
+        border: none;
+        outline:none;
+    }
+
+    .card:hover {
+        transition-duration: 500ms;
+        box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.4);
+    }
+
+    .hover {
+        height: 100%;
+    }
+
+    img {
+        display: flex;
+        max-width: 180px;
+        max-height: 200px;
+        transition-duration: 500ms;
+        margin-left: auto;
+        margin-right: auto;
+        opacity: .9;
+    }
+
+    img:hover {
+        opacity: 1;
+        transition-duration: 500ms;
+    }
+
+    .dj_name {
+        text-align: center;
+        color: var(--primary-color);
+        font-size: 20px;
+    }
+
+    .date {
+        text-align: center;
+        color: var(--primary-color);
+    }
+
+</style>
+
+<button class="card" on:click={open_recording}>
+    <div class="hover">
+        <img src={background_source} alt="dj_pic">
+    </div>
+    <div class="footer">
+        <div class="dj_name" style="--primary-color:{$base_text_color}">{dj_name} ({songs})</div>
+        <div class="date" style="--primary-color:{$sub_text_color}">{get_date(date)}</div>
+    </div>
+</button>

--- a/src/RecordingControls.svelte
+++ b/src/RecordingControls.svelte
@@ -1,20 +1,9 @@
 <script>
-    function forceStop() {
-        fetch(`http://localhost:8080/stop`, {
-            method: 'GET',
-        });
-    }
-
-    function startRecording() {
-        fetch(`http://localhost:8080/start`, {
-            method: 'GET',
-        });
-    }
-
-    function refreshRecording() {
-        fetch(`http://localhost:8080/refresh`, {
-            method: 'GET',
-        });
+    import { send_stream_action } from './stores.js';
+    
+    function stream_action(action) {
+        let promise = send_stream_action(action);
+        promise.then(value => console.log(value));
     }
 </script>
 
@@ -38,6 +27,6 @@
 
 <h2>Recording Controls</h2>
 
-<button class="material-icons" on:click={forceStop}>not_interested</button>
-<button class="material-icons" on:click={startRecording}>play_arrow</button>
-<button class="material-icons" on:click={refreshRecording}>refresh</button>
+<button class="material-icons" on:click={() => stream_action("stop")}>not_interested</button>
+<button class="material-icons" on:click={() => stream_action("start")}>play_arrow</button>
+<button class="material-icons" on:click={() => stream_action("refresh")}>refresh</button>

--- a/src/ServerSettingsModal.svelte
+++ b/src/ServerSettingsModal.svelte
@@ -1,5 +1,7 @@
 <script>
-    import { createEventDispatcher, onDestroy } from 'svelte';
+	import { createEventDispatcher, onDestroy } from 'svelte';
+	
+	export let use_submission = true;
 
 	const dispatch = createEventDispatcher();
     const close = () => dispatch('close');
@@ -56,8 +58,12 @@
 	<!-- svelte-ignore a11y-autofocus -->
 	<!-- <button autofocus on:click={close}>close modal</button> -->
     <div class="user-actions">
-        <span class="cancel" on:click={close}>Cancel</span>
-        <span class="accept" on:click={submission}>Accept</span>
+		{#if use_submission}
+			<span class="cancel" on:click={close}>Cancel</span>
+			<span class="accept" on:click={submission}>Accept</span>
+		{:else}
+			<span class="accept" on:click={close}>Close</span>
+		{/if}
     </div>
 </div>
 
@@ -69,6 +75,7 @@
 		width: 100%;
 		height: 100%;
 		background: rgba(0,0,0,0.3);
+		z-index: 1;
 	}
 
 	.modal {
@@ -77,13 +84,14 @@
 		top: 50%;
 		width: calc(100vw - 4em);
 		max-width: 38em;
-		max-height: calc(100vh - 4em);
+		max-height: 70%;
 		overflow: auto;
 		transform: translate(-50%,-50%);
 		padding: 1em;
 		border-radius: 0.2em;
 		background: white;
         box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.3), 0 6px 20px 0 rgba(0, 0, 0, 0.29);
+		z-index: 2;
 	}
 
 	button {

--- a/src/stores.js
+++ b/src/stores.js
@@ -99,10 +99,25 @@ query {
     past_recordings {
         recordings {
             folder,
-            songs
+            songs,
+            cover
         }
     }
 }`;
+
+const full_recording_query = (folder) => `
+    query {
+        full_recording(folder: "${folder}") {
+            songs
+        }
+    }`
+;
+
+const recording_controls_query = (action) => `
+    mutation {
+        streamAction(action: "${action}")
+    }
+`;
 
 const mutate_config_query = (config_data) => `
     mutation {
@@ -166,6 +181,22 @@ export function update_past_recordings() {
         {},
         past_recordings_query,
     ));
+}
+
+export function query_full_recordings(folder) {
+    return fetchGraphQL(
+        graphql_url,
+        {},
+        full_recording_query(folder)
+    );
+}
+
+export function send_stream_action(action) {
+    return fetchGraphQL(
+        graphql_url,
+        {},
+        recording_controls_query(action)
+    )
 }
 
 update_objects();

--- a/src/stores.js
+++ b/src/stores.js
@@ -108,7 +108,11 @@ query {
 const full_recording_query = (folder) => `
     query {
         full_recording(folder: "${folder}") {
-            songs
+            songs {
+                title
+                artist
+                file
+            }
         }
     }`
 ;

--- a/src/theme.js
+++ b/src/theme.js
@@ -15,3 +15,5 @@ export const sub_text_color = writable("gray");
 export const hover_color = writable("lightgray");
 
 export const input_hover_color = writable("yellow");
+
+export const primary_light = writable("#EBF6FA");


### PR DESCRIPTION
Changed past recordings to be a list of cards that contain a short date, dj name, and picture of the dj. Clicking these cards will have the song list popup as a modal with the full artist/song name, a duration of the song (if possible), and allows for playback through the webpage.

This involves changed api endpoints, making it incompatible with Nora 1.03 and below.