### PR TITLE
drag/no-drag, user-selects, and new loading icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-radio-interface",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Svelte GUI for Nora",
   "main": "public/index.html",
   "scripts": {

--- a/src/DropdownMenu.svelte
+++ b/src/DropdownMenu.svelte
@@ -67,6 +67,10 @@
 <svelte:window on:keydown={handle_keydown}/>
 
 <style>
+    .menu-container {
+        -webkit-app-region: no-drag;
+    }
+
     .material-icons {
         color: var(--primary-color);
         margin-top: 5px;
@@ -80,6 +84,10 @@
 
     .material-icons:hover {
         box-shadow: 6px 6px  var(--shadow-color);
+    }
+
+    .material-icons:focus {
+        background-color: rgba(0, 0, 0, 0);
     }
 
     .open-menu-icon {
@@ -133,38 +141,40 @@
     }
 </style>
 
-<button on:click={openMenu} class="{menu_open ? 'material-icons open-menu-icon' : 'material-icons'}" style="--primary-color:{$text_on_color}; --shadow-color:{$highlight}">
-    { menu_open ? 'menu_open' : 'menu' }
-</button>
+<div class="menu-container">
+    <button on:click={openMenu} class="{menu_open ? 'material-icons open-menu-icon' : 'material-icons'}" style="--primary-color:{$text_on_color}; --shadow-color:{$highlight}">
+        { menu_open ? 'menu_open' : 'menu' }
+    </button>
 
-{#if menu_open}
-    <div class="dropdown-content">
-        <span on:click={serverSettings} style="--hover-color:{$hover_color}">Change Server Settings</span>
-        {#if $current_page == "main"}
-            <span on:click={pastRecordings} style="--hover-color:{$hover_color}">Show Past Recordings</span>
-        {:else}
-            <span on:click={mainPage} style="--hover-color:{$hover_color}">Show Controls</span>
-        {/if}
-    </div>
-    <div class="menu-background" on:click="{() => menu_open = false}"></div>
-{/if}
+    {#if menu_open}
+        <div class="dropdown-content">
+            <span on:click={serverSettings} style="--hover-color:{$hover_color}">Change Server Settings</span>
+            {#if $current_page == "main"}
+                <span on:click={pastRecordings} style="--hover-color:{$hover_color}">Show Past Recordings</span>
+            {:else}
+                <span on:click={mainPage} style="--hover-color:{$hover_color}">Show Controls</span>
+            {/if}
+        </div>
+        <div class="menu-background" on:click="{() => menu_open = false}"></div>
+    {/if}
 
-{#if open_modal}
-    <ServerSettingsModal on:close="{() => open_modal = false}" on:submission={submit}>
-        <div class="modal-title" slot="header">Change your server settings</div>
-        {#await config_promise}
-            loading
-        {:then value}
-            <div class="form-input">
-                <FancyInput id="api_uri" label="API URI" bind:value={config_data.api_uri}></FancyInput>
-                <FancyInput id="server_uri" label="Server URI" bind:value={config_data.server_uri}></FancyInput>
-                <FancyInput id="stream_uri" label="Stream URI" bind:value={config_data.stream_uri}></FancyInput>
-                <FancyInput id="poll_interval" label="Poll Interval" bind:value={config_data.poll_interval}></FancyInput>
-                <FancyInput id="excluded_djs" label="Excluded DJs" hint_text="JSON array of strings" bind:value={config_data.excluded_djs}></FancyInput>
-                <FancyInput id="export_folder" label="Export Folder" hint_text="Leave empty for same directory as file" bind:value={config_data.export_folder}></FancyInput>
-            </div>
-        {:catch error}
-            {error.message}
-        {/await}
-    </ServerSettingsModal>
-{/if}
+    {#if open_modal}
+        <ServerSettingsModal on:close="{() => open_modal = false}" on:submission={submit}>
+            <div class="modal-title" slot="header">Change your server settings</div>
+            {#await config_promise}
+                loading
+            {:then value}
+                <div class="form-input">
+                    <FancyInput id="api_uri" label="API URI" bind:value={config_data.api_uri}></FancyInput>
+                    <FancyInput id="server_uri" label="Server URI" bind:value={config_data.server_uri}></FancyInput>
+                    <FancyInput id="stream_uri" label="Stream URI" bind:value={config_data.stream_uri}></FancyInput>
+                    <FancyInput id="poll_interval" label="Poll Interval" bind:value={config_data.poll_interval}></FancyInput>
+                    <FancyInput id="excluded_djs" label="Excluded DJs" hint_text="JSON array of strings" bind:value={config_data.excluded_djs}></FancyInput>
+                    <FancyInput id="export_folder" label="Export Folder" hint_text="Leave empty for same directory as file" bind:value={config_data.export_folder}></FancyInput>
+                </div>
+            {:catch error}
+                {error.message}
+            {/await}
+        </ServerSettingsModal>
+    {/if}
+</div>

--- a/src/Footer.svelte
+++ b/src/Footer.svelte
@@ -62,6 +62,9 @@
         flex-direction: column;
         font-size: 15px;
         text-align: center;
+        -webkit-user-select: none; /* Safari */
+        -ms-user-select: none; /* IE 10+ and Edge */
+        user-select: none; /* Standard syntax */
     }
 
     .song-name {

--- a/src/Header.svelte
+++ b/src/Header.svelte
@@ -12,6 +12,10 @@
         flex-direction: row;
         justify-content: flex-end;
         line-height: 40px;
+        -webkit-user-select: none; /* Safari */
+        -ms-user-select: none; /* IE 10+ and Edge */
+        user-select: none; /* Standard syntax */
+        -webkit-app-region: drag;
     }
     
     p {

--- a/src/LastPlayed.svelte
+++ b/src/LastPlayed.svelte
@@ -27,6 +27,9 @@
 
     p {
         font-size: 20px;
+        -webkit-user-select: none; /* Safari */
+        -ms-user-select: none; /* IE 10+ and Edge */
+        user-select: none; /* Standard syntax */
     }
 </style>
 

--- a/src/Main.svelte
+++ b/src/Main.svelte
@@ -23,6 +23,9 @@
         flex-direction: column;
         margin-left: auto;
         margin-right: auto;
+        -webkit-user-select: none; /* Safari */
+        -ms-user-select: none; /* IE 10+ and Edge */
+        user-select: none; /* Standard syntax */
     }
 
     .top {

--- a/src/PastRecordings.svelte
+++ b/src/PastRecordings.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { update_past_recordings, past_recordings_object, query_full_recordings } from './stores.js';
+    import { update_past_recordings, past_recordings_object, query_full_recordings, graphql_base } from './stores.js';
     import { sub_text_color } from './theme.js';
     import RecordingCard from './RecordingCard.svelte';
     import ServerSettingsModal from './ServerSettingsModal.svelte';
@@ -9,7 +9,7 @@
         songs_promise = query_full_recordings(folder);
         show_recording_modal = true;
         modal_title = folder.split(' ')[1];
-        modal_date = get_date(folder.split(' ')[0]);
+        modal_date = `${get_date(folder.split(' ')[0])} (${folder.split(' ')[0]})`;
         modal_folder = folder;
     }
 
@@ -38,7 +38,7 @@
     .song-list {
         display: flex;
         flex-direction: column;
-        max-height: 600px;
+        max-height: 520px;
         overflow-y: auto;
     }
 
@@ -57,6 +57,25 @@
 
     h1 {
         text-align: center;
+        -webkit-user-select: none; /* Safari */
+        -ms-user-select: none; /* IE 10+ and Edge */
+        user-select: none; /* Standard syntax */
+    }
+
+    .loader {
+        margin-left: auto;
+        margin-right: auto;
+        border: 0px solid #f3f3f3; /* Light grey */
+        border-top: 5px solid #3498db; /* Blue */
+        border-radius: 50%;
+        width: 48px;
+        height: 48px;
+        animation: spin 2s linear infinite;
+    }
+
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
     }
 </style>
 
@@ -65,11 +84,11 @@
 
     <div class="card-display">
         {#await $past_recordings_object}
-            <p>Fetching recordings</p>
+            <div class="loader"></div>
         {:then value}
             {#each value.data.past_recordings.recordings as {folder, songs, cover}}
                 <RecordingCard 
-                    background_source={`http://localhost:4000/${cover}`}
+                    background_source={`${graphql_base}/${cover}`}
                     folder={folder}
                     songs={songs}
                     on:open="{() => open_recording(folder)}"
@@ -87,7 +106,7 @@
 {#if show_recording_modal}
     <ServerSettingsModal on:close="{() => show_recording_modal = false}" use_submission={false}>
         {#await songs_promise}
-            loading
+            <div class="loader"></div>
         {:then value}
             <div slot="header">
                 <div class="modal-title">
@@ -99,7 +118,7 @@
             </div>
             <div class="song-list">
                 {#each value.data.full_recording.songs as song, index}
-                    <RecordedSong src={`http://localhost:4000/${modal_folder}/${song.file}`} {song} {index}></RecordedSong>
+                    <RecordedSong src={`${graphql_base}/${modal_folder}/${song.file}`} {song} {index}></RecordedSong>
                 {:else}
                     <p>No songs found.</p>
                 {/each}

--- a/src/RecordingCard.svelte
+++ b/src/RecordingCard.svelte
@@ -32,11 +32,16 @@
         cursor: pointer;
         border: none;
         outline:none;
+        
     }
 
     .card:hover {
         transition-duration: 500ms;
         box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.4);
+    }
+
+    .card::-moz-focus-inner {
+        border: 0;
     }
 
     .hover {

--- a/src/RecordingControls.svelte
+++ b/src/RecordingControls.svelte
@@ -44,16 +44,28 @@
         padding-right: 15px;
         cursor: pointer;
         transition: 0.3s;
+        border-radius:100px;
     }
 
     .material-icons:hover {
         box-shadow: 0px 8px  rgba(0,0,0,0.6);
-        border-radius:100px;
+    }
+
+    .material-icons::-moz-focus-inner {
+        border: 0;
+    }
+
+    .controls-container {
+        -webkit-user-select: none; /* Safari */
+        -ms-user-select: none; /* IE 10+ and Edge */
+        user-select: none; /* Standard syntax */
     }
 </style>
 
-<h2>Recording Controls</h2>
+<div class="controls-container">
+    <h2>Recording Controls</h2>
 
-<button class="material-icons" on:click={() => stream_action("stop")}>not_interested</button>
-<button class="material-icons" on:click={() => stream_action("start")}>play_arrow</button>
-<button class="material-icons" on:click={() => stream_action("refresh")}>refresh</button>
+    <button class="material-icons" on:click={() => stream_action("stop")}>not_interested</button>
+    <button class="material-icons" on:click={() => stream_action("start")}>play_arrow</button>
+    <button class="material-icons" on:click={() => stream_action("refresh")}>refresh</button>
+</div>

--- a/src/ServerSettingsModal.svelte
+++ b/src/ServerSettingsModal.svelte
@@ -101,6 +101,7 @@
     .user-actions {
         display: flex;
         justify-content: flex-end;
+		line-height: 40px;
     }
 
     .cancel {

--- a/src/StreamStatus.svelte
+++ b/src/StreamStatus.svelte
@@ -21,6 +21,9 @@
         margin-bottom: auto;
         margin-left: 15px;
         margin-right: 15px;
+        -webkit-user-select: none; /* Safari */
+        -ms-user-select: none; /* IE 10+ and Edge */
+        user-select: none; /* Standard syntax */
     }
 </style>
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -138,7 +138,9 @@ const mutate_config_query = (config_data) => `
     }
 `;
 
-const graphql_url = 'http://localhost:4000/graphql';
+export const graphql_base = 'http://localhost:4000';
+
+const graphql_url = `${graphql_base}/graphql`;
 
 function update_objects() {
     fetchGraphQL(


### PR DESCRIPTION
Touches up some of the css, as well as prepares the app for electron integration:

- user-select: none for most text, aside from last played songs and the current DJ
- dragging enabled for the header, and no-drag for the menu
- loading animation for the past recordings page instead of plain text